### PR TITLE
Optionally disable retrieval of ACL.

### DIFF
--- a/lib/io.dart
+++ b/lib/io.dart
@@ -47,7 +47,7 @@ extension StorageX on S3Storage {
     StorageInvalidBucketNameError.check(bucket);
     StorageInvalidObjectNameError.check(object);
 
-    final stat = await statObject(bucket, object);
+    final stat = await statObject(bucket, object, getAcl: false);
     final dir = dirname(filePath);
     await Directory(dir).create(recursive: true);
 

--- a/lib/src/s3.dart
+++ b/lib/src/s3.dart
@@ -1103,7 +1103,7 @@ class S3Storage {
   /// 
   /// When [getAcl] is false, the result will always have a null [acl] (e.g. Access Controll Policy).
   /// Can be usefull if you don't have [s3:GetObjectAcl] permissions or to increase performance
-  Future<StatObjectResult> statObject(String bucket, String object, {bool getAcl = false}) async {
+  Future<StatObjectResult> statObject(String bucket, String object, {bool getAcl = true}) async {
     StorageInvalidBucketNameError.check(bucket);
     StorageInvalidObjectNameError.check(object);
 

--- a/lib/src/s3.dart
+++ b/lib/src/s3.dart
@@ -1100,7 +1100,10 @@ class S3Storage {
   }
 
   /// Stat information of the object.
-  Future<StatObjectResult> statObject(String bucket, String object) async {
+  /// 
+  /// When [getAcl] is false, the result will always have a null [acl] (e.g. Access Controll Policy).
+  /// Can be usefull if you don't have [s3:GetObjectAcl] permissions or to increase performance
+  Future<StatObjectResult> statObject(String bucket, String object, {bool getAcl = false}) async {
     StorageInvalidBucketNameError.check(bucket);
     StorageInvalidObjectNameError.check(object);
 
@@ -1122,7 +1125,7 @@ class S3Storage {
       size: int.parse(resp.headers['content-length']!),
       metaData: extractMetadata(resp.headers),
       lastModified: parseRfc7231Time(resp.headers['last-modified']!),
-      acl: await getObjectACL(bucket, object),
+      acl: getAcl ? await getObjectACL(bucket, object) : null,
     );
   }
 }


### PR DESCRIPTION
### Rationale

Calls to `statObject()` and `fGetObject()` fail (throw an exception) if you don't have `s3:GetObjectAcl` permissions on target S3 store.  

### Cause

This happens because calls to `statObject` retrieves the access control list for an object.  

### Fix

Optionally disable collection of the access control list.   In this case the returned `StatObjectResult` will have a null `acl` field.  Note this is fully backwards compatible as the new `getAcl` parameter is optional and the `acl` field is already nullable.

```Dart
// Old API
 Future<StatObjectResult> statObject(String bucket, String object) async {

// New API
 Future<StatObjectResult> statObject(String bucket, String object, {bool getAcl = true}) async {

```